### PR TITLE
luarocks build works properly on osx and linux now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LUA_VERSION_NUMBER = 5.1
 
 CC = gcc
 CFLAGS = `pkg-config --cflags $(LUA_VERSION)` -fPIC -O2 #-Wall
-INSTALL_PATH = $(pkg-config $(LUA_VERSION) --variable=INSTALL_CMOD)
+INSTALL_PATH = $(shell pkg-config $(LUA_VERSION) --variable=libdir)/$(LUA_VERSION)/$(LUA_VERSION_NUMBER)
 
 OS_NAME = $(shell uname -s)
 MH_NAME = $(shell uname -m)
@@ -51,4 +51,3 @@ ifeq ($(OS_NAME), Darwin)
 else
 	install -D -s zklua.so $(INSTALL_PATH)/zklua.so
 endif
-	


### PR DESCRIPTION
**Note**: updated the install directory so that requires work correctly in both environments

This should be ready to push to luarocks after this is merged, let me know if there's anything I can do to help #2 get closed.
### osx

``` bash
jtoft@mogu: Desktop/zklua> luarocks build rockspec/zklua-scm-0.rockspec
Cloning into 'zklua'...
remote: Counting objects: 21, done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 21 (delta 1), reused 17 (delta 1)
Receiving objects: 100% (21/21), 25.25 KiB | 0 bytes/s, done.
Resolving deltas: 100% (1/1), done.
Checking connectivity... done.
export MACOSX_DEPLOYMENT_TARGET=10.5; gcc -O2 -fPIC -I/usr/local/opt/lua/include -c zklua.c -o zklua.o
export MACOSX_DEPLOYMENT_TARGET=10.5; gcc -bundle -undefined dynamic_lookup -all_load -o zklua.so -L/usr/local/opt/lua/lib zklua.o
Updating manifest for /usr/local/lib/luarocks/rocks
No existing manifest. Attempting to rebuild...

zklua scm-0 is now built and installed in /usr/local (license: APACHE LICENSE/2.0)
```
### linux

``` bash
[root@pack zklua]# luarocks build rockspec/zklua-scm-0.rockspec
Cloning into 'zklua'...
remote: Counting objects: 21, done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 21 (delta 1), reused 17 (delta 1)
Receiving objects: 100% (21/21), 25.25 KiB | 0 bytes/s, done.
Resolving deltas: 100% (1/1), done.
Checking connectivity... done.
gcc -O2 -fPIC -I/usr/include -c zklua.c -o zklua.o
gcc -shared -o zklua.so -L/usr/lib zklua.o
Updating manifest for /usr/lib/luarocks/rocks
No existing manifest. Attempting to rebuild...

zklua scm-0 is now built and installed in /usr (license: APACHE LICENSE/2.0)
```
