### PR TITLE
This method does cause runtime error on require "zklua"

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -1668,7 +1668,7 @@ static const luaL_Reg zklua[] =
     {"recv_timeout", zklua_recv_timeout},
     {"get_context", zklua_get_context},
     {"set_watcher", zklua_set_watcher},
-    {"get_connected_host", zklua_get_connected_host},
+//    {"get_connected_host", zklua_get_connected_host},
     {"interest", zklua_interest},
     {"process", zklua_process},
     {"state", zklua_state},


### PR DESCRIPTION
For some odd reason, having this method causes a runtime lua error on "require zklua" with current libzookeeper_mt.so.

Tested under linux.
