### PR TITLE
get call broken, will never return node data

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -1409,8 +1409,8 @@ static int zklua_get(lua_State *L)
 {
     size_t path_len = 0;
     const char *path = NULL;
-    char *buffer = NULL;
-    int buffer_len = 0;
+    char *buffer = malloc(2048);
+    int buffer_len = 2048;
     int watch = 0;
     struct Stat stat;
     int ret = -1;
@@ -1422,6 +1422,7 @@ static int zklua_get(lua_State *L)
         ret = zoo_get(handle->zh, path, watch, buffer, &buffer_len, &stat);
         lua_pushinteger(L, ret);
         lua_pushlstring(L, buffer, buffer_len);
+        free(buffer);
         _zklua_build_stat(L, &stat);
         return 3;
     } else {


### PR DESCRIPTION
get calls (not just this one!) need buffer/memory controll. ZK will not malloc for us. Without this change znode data cannot be read out.

This change only allows up to 2K data to be read, but a znode can have up to 1MB of data, so it probably needs a more clever mechanism.
