### PR TITLE
lua table indices start at 1 not 0

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -307,7 +307,7 @@ static int _zklua_build_acls(lua_State *L, const struct ACL_vector *acls)
             lua_pushstring(L, "id");
             lua_pushstring(L, acls->data[i].id.id);
             lua_settable(L, -3);
-            lua_rawseti(L, -2, i);
+            lua_rawseti(L, -2, i+1);
         }
     }
     return 0;


### PR DESCRIPTION
lua table indices start at 1 not 0 as in C. For consistency and to be able to use the ACL table returned by get_acl in the set_acl (and create) call, fixed off by one error.
