### PR TITLE
fix lua table index for build_string vector

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -285,7 +285,7 @@ static int _zklua_build_string_vector(lua_State *L, const struct String_vector *
     if (sv != NULL) {
         for (i = 0; i < sv->count; ++i) {
             lua_pushstring(L, sv->data[i]);
-            lua_rawseti(L, -2, i);
+            lua_rawseti(L, -2, i+1);
         }
     }
     return 0;


### PR DESCRIPTION
Another issue where lua tables start at index 0 instead of 1. This caused checks for example for number of children in 
ret, children = zklua.get_children(zh, path, 0)
to return 0 to a subsequent size check with #children as the table is { 0 -> firstchild }

With this change, the first children entry will be pushed to lua index 1 and #children will work as expected as will all standard lua iterator functions that expect arrays to start at 1.
