### PR TITLE
去掉文件中‘-’符号和重复的include文件

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
-_
+
 #include "zklua.h"
 
 static FILE *zklua_log_stream = NULL;

--- a/zklua.c
+++ b/zklua.c
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifndef WIN32
 #include <netinet/in.h>


### PR DESCRIPTION
自己在clone后，安装出现各种问题，在修改以上两处后安装成功。
