### PR TITLE
Update zklua.c

### DIFF
--- a/zklua.c
+++ b/zklua.c
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
-_
+
 #include "zklua.h"
 
 static FILE *zklua_log_stream = NULL;


### PR DESCRIPTION
Remove  unexpected character '_', which leading to compile error below:

gcc -c `pkg-config --cflags lua` -fPIC -O2 -std=gnu99  zklua.c
In file included from /usr/local/include/lua.h:13,
                 from zklua.h:24,
                 from zklua.c:29:
/usr/lib/gcc/x86_64-redhat-linux/4.4.6/include/stddef.h:149: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'typedef'